### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,27 +5,27 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-LKM1638Board		KEYWORD1
-lkm1638				KEYWORD1
+LKM1638Board	KEYWORD1
+lkm1638	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getButtons			KEYWORD2
-clear				KEYWORD2
-setColorLED			KEYWORD2
-setColorLEDsOn		KEYWORD2
-setColorLEDsOff		KEYWORD2
-refresh				KEYWORD2
-dotOn				KEYWORD2
-dotOff				KEYWORD2
-setDots				KEYWORD2
-setPrintPos			KEYWORD2
-getPrintPos			KEYWORD2
+getButtons	KEYWORD2
+clear	KEYWORD2
+setColorLED	KEYWORD2
+setColorLEDsOn	KEYWORD2
+setColorLEDsOff	KEYWORD2
+refresh	KEYWORD2
+dotOn	KEYWORD2
+dotOff	KEYWORD2
+setDots	KEYWORD2
+setPrintPos	KEYWORD2
+getPrintPos	KEYWORD2
 setSegmentsDigit	KEYWORD2
-setDigit			KEYWORD2
-print				KEYWORD2
+setDigit	KEYWORD2
+print	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -34,12 +34,12 @@ print				KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-NUM_LEDS			LITERAL1
-NUM_DIGITS			LITERAL1
-SEGMENTS_OFF		LITERAL1
-SEGMENTS_MINUS		LITERAL1
-SEGMENTS_DEGREE		LITERAL1
-SEGMENTS_C			LITERAL1
-LedOff				LITERAL1
-LedRed				LITERAL1
-LedGreen			LITERAL1
+NUM_LEDS	LITERAL1
+NUM_DIGITS	LITERAL1
+SEGMENTS_OFF	LITERAL1
+SEGMENTS_MINUS	LITERAL1
+SEGMENTS_DEGREE	LITERAL1
+SEGMENTS_C	LITERAL1
+LedOff	LITERAL1
+LedRed	LITERAL1
+LedGreen	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords